### PR TITLE
Update EnemyCaC.controller and MonoBehaviors in SampleScene

### DIFF
--- a/Assets/Art/Animations/Enemies/Xaoling/EnemyCaC.controller
+++ b/Assets/Art/Animations/Enemies/Xaoling/EnemyCaC.controller
@@ -159,7 +159,7 @@ AnimatorStateTransition:
   m_Name: 
   m_Conditions:
   - m_ConditionMode: 1
-    m_ConditionEvent: Jump
+    m_ConditionEvent: isWalking
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: -3487889083328304963}
@@ -232,12 +232,6 @@ AnimatorController:
   m_Name: EnemyCaC
   serializedVersion: 5
   m_AnimatorParameters:
-  - m_Name: Jump
-    m_Type: 9
-    m_DefaultFloat: 0
-    m_DefaultInt: 0
-    m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
   - m_Name: Hit
     m_Type: 9
     m_DefaultFloat: 0
@@ -246,6 +240,24 @@ AnimatorController:
     m_Controller: {fileID: 9100000}
   - m_Name: Attack
     m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  - m_Name: isWalking
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  - m_Name: Jump
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  - m_Name: isGrounded
+    m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -394,14 +394,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.5754717, g: 0, b: 0, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 0}
+  m_Sprite: {fileID: 21300000, guid: cd3c9126cdf869448badfeac13cf3d25, type: 3}
   m_Type: 3
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -16686,7 +16686,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.07450981, g: 0.11372549, b: 0.0812367, a: 1}
+  m_Color: {r: 0.21960786, g: 0.21960786, b: 0.21960786, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -24266,6 +24266,7 @@ MonoBehaviour:
   restartDelay: 0.1
   useCheckpoints: 0
   defaultSpawnPoint: {fileID: 985615482}
+  playerHealth: {fileID: 1049642241}
   useRestartEffect: 1
   restartEffectPrefab: {fileID: 0}
   restartSound: {fileID: 0}
@@ -26719,9 +26720,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   maxHealth: 100
-  onDeath:
-    m_PersistentCalls:
-      m_Calls: []
   onDamage:
     m_PersistentCalls:
       m_Calls: []
@@ -107287,9 +107285,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   maxHealth: 100
-  onDeath:
-    m_PersistentCalls:
-      m_Calls: []
   onDamage:
     m_PersistentCalls:
       m_Calls: []


### PR DESCRIPTION
Updated animation parameters in EnemyCaC.controller:
- Changed condition event from `Jump` to `isWalking`.
- Removed `Jump`, `Hit`, and `Attack` parameters.
- Added `isWalking` and `isGrounded` parameters.
- Re-added `Jump` parameter with original properties.

Modified MonoBehaviors in SampleScene.unity:
- Adjusted `m_Color` and `m_Sprite` properties for UI elements.
- Added `playerHealth` property to a MonoBehavior.
- Removed `onDeath` property and its associated calls.