### PR TITLE
Invoke OnHealthChanged event in Die() method

### DIFF
--- a/Assets/Scripts/Core/Components/HealthComponent.cs
+++ b/Assets/Scripts/Core/Components/HealthComponent.cs
@@ -141,6 +141,7 @@ public class HealthComponent : MonoBehaviour
     private void Die()
     {
         onDeath?.Invoke(); // Dispara evento de muerte
+        OnHealthChanged?.Invoke(-1, maxHealth);
         gameObject.SetActive(false);
     }
 }


### PR DESCRIPTION
Added a call to the `OnHealthChanged` event in the `Die()` method of the `HealthComponent` class. The event is invoked with parameters `-1` (indicating death) and `maxHealth` before deactivating the game object. This ensures that health change listeners are notified upon death.